### PR TITLE
Add nginx installation script

### DIFF
--- a/index.json
+++ b/index.json
@@ -10,5 +10,11 @@
       "path": "scripts/docker.sh",
       "params": [],
       "desc": "Checks if Docker is installed; if not, installs it and adds the current user to the 'docker' group."
+    },
+    {
+      "name": "Nginx Installer",
+      "path": "scripts/nginx.sh",
+      "params": [],
+      "desc": "Installs nginx, enables and starts the nginx service. Also installs certbot for nginx."
     }
   ]

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+COLOR_GREEN='\033[0;32m'
+NO_COLOR='\033[0m'
+
+# Update package lists
+sudo apt update
+
+# Install nginx
+sudo apt install -y nginx
+
+# Enable nginx service
+sudo systemctl enable nginx
+
+# Install certbot
+sudo snap install --classic certbot
+
+# Start nginx service
+sudo systemctl start nginx
+
+echo -e "${COLOR_GREEN}nginx and certbot installed and started successfully.${NO_COLOR}"


### PR DESCRIPTION
Add a new script `nginx.sh` to install nginx and certbot, and update `index.json` to reflect the new script.

* **scripts/nginx.sh**
  - Create a new script to install nginx.
  - Update package lists and install nginx.
  - Install certbot for nginx.
  - Enable and start the nginx service.
  - Print a success message.

* **index.json**
  - Add an entry for the new `nginx.sh` script.
  - Include name, path, params, and description.
  - Update description to mention certbot installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rohittp0/scripts/pull/1?shareId=08f8e48e-c18a-4fdf-9590-491dddf89ae4).