### PR TITLE
Add script to create SSH key and add to agent

### DIFF
--- a/index.json
+++ b/index.json
@@ -16,5 +16,11 @@
       "path": "scripts/nginx.sh",
       "params": [],
       "desc": "Installs nginx, enables and starts the nginx service. Also installs certbot for nginx."
+    },
+    {
+      "name": "Create SSH Key",
+      "path": "scripts/create_ssh_key.sh",
+      "params": ["Key Name"],
+      "desc": "Creates an SSH key at ~/.ssh/$1, adds it to the SSH agent, and prints the public key."
     }
   ]

--- a/scripts/create_ssh_key.sh
+++ b/scripts/create_ssh_key.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if a key name is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <key_name>"
+    exit 1
+fi
+
+KEY_PATH="$HOME/.ssh/$1"
+
+# Check if the key already exists
+if [ -f "$KEY_PATH" ]; then
+    echo "Warning: The key $KEY_PATH already exists. Skipping creation."
+    exit 0
+fi
+
+# Generate SSH key
+ssh-keygen -f "$KEY_PATH" -N ""
+
+# Start the SSH agent if not running
+if ! pgrep -u "$USER" ssh-agent > /dev/null; then
+    eval "$(ssh-agent -s)"
+fi
+
+# Add the SSH key to the agent
+ssh-add "$KEY_PATH"
+
+# Print the public key
+cat "${KEY_PATH}.pub"

--- a/scripts/create_ssh_key.sh
+++ b/scripts/create_ssh_key.sh
@@ -8,6 +8,11 @@ fi
 
 KEY_PATH="$HOME/.ssh/$1"
 
+# Ensure ~/.ssh directory exists
+if [ ! -d "$HOME/.ssh" ]; then
+    mkdir -m 700 "$HOME/.ssh"
+fi
+
 # Check if the key already exists
 if [ -f "$KEY_PATH" ]; then
     echo "Warning: The key $KEY_PATH already exists. Skipping creation."


### PR DESCRIPTION
Add a new script to create an SSH key, add it to the SSH agent, and print the public key.

* **New Script (`scripts/create_ssh_key.sh`)**
  - Create an SSH key at `~/.ssh/$1`.
  - Add the generated key to the SSH agent.
  - Print the public key of the generated key.
  - Check if the key already exists, if it does, print a warning and skip creation.
  - Revise the ssh-keygen command to create a deploy key for GitHub.

* **Update `index.json`**
  - Add a new entry for the `create_ssh_key.sh` script.
  - Include the name, path, params, and description of the script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rohittp0/scripts/pull/2?shareId=5a44012b-1579-41d1-808b-6ce92ebfd1a4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new script for creating SSH keys
	- Provides ability to generate SSH keys with a custom name
	- Automatically adds the key to the SSH agent
	- Prints the public key for easy sharing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->