### PR TITLE
Add SSH key script

### DIFF
--- a/index.json
+++ b/index.json
@@ -28,5 +28,11 @@
       "path": "scripts/password_less_sudo.sh",
       "params": ["User Name"],
       "desc": "Enables sudo access and password-less sudo access for the provided user."
+    },
+    {
+      "name": "Add SSH Key",
+      "path": "scripts/add_ssh_key.sh",
+      "params": ["Public Key"],
+      "desc": "Adds the provided SSH public key to the authorized_keys file."
     }
   ]

--- a/scripts/add_ssh_key.sh
+++ b/scripts/add_ssh_key.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if a public key is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <public_key>"
+    exit 1
+fi
+
+PUBLIC_KEY="$1"
+AUTHORIZED_KEYS_FILE="$HOME/.ssh/authorized_keys"
+
+# Ensure ~/.ssh directory exists
+if [ ! -d "$HOME/.ssh" ]; then
+    mkdir -m 700 "$HOME/.ssh"
+fi
+
+# Append the public key to the authorized_keys file
+echo "$PUBLIC_KEY" >> "$AUTHORIZED_KEYS_FILE"
+
+echo "Public key added to $AUTHORIZED_KEYS_FILE"

--- a/scripts/add_ssh_key.sh
+++ b/scripts/add_ssh_key.sh
@@ -9,6 +9,10 @@ if [ -z "$1" ]; then
     echo >&2 "Usage: $0 <public_key>"
     exit 1
 fi
+if [ -z "$1" ]; then
+    echo >&2 "Usage: $0 <public_key>"
+    exit 1
+fi
 
 PUBLIC_KEY="$1"
 AUTHORIZED_KEYS_FILE="$HOME/.ssh/authorized_keys"

--- a/scripts/add_ssh_key.sh
+++ b/scripts/add_ssh_key.sh
@@ -9,10 +9,6 @@ if [ -z "$1" ]; then
     echo >&2 "Usage: $0 <public_key>"
     exit 1
 fi
-if [ -z "$1" ]; then
-    echo >&2 "Usage: $0 <public_key>"
-    exit 1
-fi
 
 PUBLIC_KEY="$1"
 AUTHORIZED_KEYS_FILE="$HOME/.ssh/authorized_keys"

--- a/scripts/add_ssh_key.sh
+++ b/scripts/add_ssh_key.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
 # Check if a public key is provided as an argument
 if [ -z "$1" ]; then
-    echo "Usage: $0 <public_key>"
+    echo >&2 "Usage: $0 <public_key>"
     exit 1
 fi
 


### PR DESCRIPTION
Add a new script to add an SSH public key to authorized keys and update index.json.

* **New Script**: Create `scripts/add_ssh_key.sh` that takes an SSH public key as a parameter and adds it to the authorized_keys file.
* **index.json**: Add a new entry for the script with the name "Add SSH Key", path "scripts/add_ssh_key.sh", params ["Public Key"], and a description.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rohittp0/scripts/pull/4?shareId=03985984-9d7f-429d-ba69-0cd3f4e0d2ea).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an option to add an SSH public key, allowing users to easily append a provided key to their authorized_keys file through a new script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->