### PR TITLE
Change version parameter to image parameter in reset_wall.sh

### DIFF
--- a/index.json
+++ b/index.json
@@ -86,7 +86,7 @@
     "path": "scripts/reset_wall.sh",
     "params": [
       "Postgres Docker Volume",
-      "Postgres Version (optional)"
+      "Postgres Image (optional, defaults to postgres:latest)"
     ],
     "desc": "Resets the Postgres write ahead log by running `pg_resetwal` from a temporary container. Use with caution will drop all pending writes."
   },

--- a/scripts/reset_wall.sh
+++ b/scripts/reset_wall.sh
@@ -4,22 +4,22 @@
 set -e
 
 VOLUME="$1"
-VERSION="$2"
+IMAGE="$2"
 
 # Input validation
 if [ -z $VOLUME ]; then
-    echo "Usage: $0 <pg_volume> [<pg_version>]"
+    echo "Usage: $0 <pg_volume> [<pg_image>]"
     exit 1
 fi
 
-if [ -z $VERSION ]; then
- VERSION="latest"
+if [ -z $IMAGE ]; then
+ IMAGE="postgres:latest"
 fi
 
 docker run --rm -it \
-  -v "${VOLUME}":/var/lib/postgresql/data \
+  -v "${VOLUME}":/var/lib/postgresql/ \
   --user postgres \
-  postgis/postgis:${VERSION} \
-  pg_resetwal -f /var/lib/postgresql/data
+  ${IMAGE} \
+  pg_resetwal -f /var/lib/postgresql/
 
 echo "PG WALL reset"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Script parameter renamed from a version to a container image; default now uses the standard Postgres image (postgres:latest).
  * Updated usage/validation text to reflect the new image parameter.
  * Adjusted runtime paths and volume mount target to match the new image behavior while preserving the same reset flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->